### PR TITLE
build and release working again

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,45 +6,65 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
+  build-linux32:
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
-
-    strategy:
-      matrix:
-        env: [linux, linux32]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up environment for ${{ matrix.env }}
+      - name: Set up environment for linux32
         run: |
           sudo apt update
-          if [ "${{ matrix.env }}" == "linux32" ]; then
-            sudo dpkg --add-architecture i386
-            sudo apt update
-            sudo apt install -y gcc-multilib g++-multilib binutils git cmake build-essential zlib1g-dev:i386 libsdl2-dev:i386 libglu1-mesa-dev:i386 libsdl2-image-dev:i386 libsdl2-mixer-dev:i386 libtheora-dev:i386 libogg-dev:i386 libvorbis-dev:i386
-          else
-            sudo apt install -y binutils git cmake build-essential zlib1g-dev libsdl2-dev libglu1-mesa-dev libsdl2-image-dev libsdl2-mixer-dev libtheora-dev libogg-dev libvorbis-dev
-          fi
+          sudo dpkg --add-architecture i386
+          sudo apt update
+          sudo apt install -y gcc-multilib g++-multilib binutils git cmake build-essential zlib1g-dev:i386 libsdl2-dev:i386 libglu1-mesa-dev:i386 libsdl2-image-dev:i386 libsdl2-mixer-dev:i386 libtheora-dev:i386 libogg-dev:i386 libvorbis-dev:i386
 
       - name: Update submodules and Build
         run: |
           git submodule update --init --recursive
           cd vendor
-          ./build-sdl-gpu.sh ${{ matrix.env }}
+          ./build-sdl-gpu.sh linux32
           cd ..
-          ./build.sh ${{ matrix.env }}
+          ./build.sh linux32
           ./build.sh packages
 
       - name: Upload BennuGD2 artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: BennuGD2-${{ matrix.env }}
+          name: BennuGD2-linux32
           path: packages/bgd2-*.tgz
 
+  build-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up environment for linux
+        run: |
+          sudo apt update
+          sudo apt install -y binutils git cmake build-essential zlib1g-dev libsdl2-dev libglu1-mesa-dev libsdl2-image-dev libsdl2-mixer-dev libtheora-dev libogg-dev libvorbis-dev
+
+      - name: Update submodules and Build
+        run: |
+          git submodule update --init --recursive
+          cd vendor
+          ./build-sdl-gpu.sh linux
+          cd ..
+          ./build.sh linux
+          ./build.sh packages
+
+      - name: Upload BennuGD2 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: BennuGD2-linux
+          path: packages/bgd2-*.tgz          
   build-windows:
     runs-on: ubuntu-latest
     permissions:
@@ -255,7 +275,7 @@ jobs:
           path: packages/x86_64-apple-darwin14-*.tgz
 
   create-release:
-    needs: [build, build-windows, build-windows-32bit, build-macosx]
+    needs: [build-linux32, build-linux, build-windows, build-windows-32bit, build-macosx]
     runs-on: ubuntu-latest
     if: success()
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up environment for ${{ matrix.env }}
         run: |
@@ -40,7 +40,7 @@ jobs:
           ./build.sh packages
 
       - name: Upload BennuGD2 artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BennuGD2-${{ matrix.env }}
           path: packages/bgd2-*.tgz
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up environment
         run: |
@@ -119,7 +119,7 @@ jobs:
           fi
 
       - name: Upload BennuGD2 artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BennuGD2-windows
           path: packages/bgd2-x86_64-w64-mingw32-*.rar
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up environment
         run: |
@@ -199,7 +199,7 @@ jobs:
           fi
 
       - name: Upload BennuGD2 artifacts for 32-bit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BennuGD2-windows32
           path: packages/bgd2-i686-w64-mingw32-*.rar
@@ -211,7 +211,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up osxcross
         run: |
@@ -249,7 +249,7 @@ jobs:
           ./build.sh packages
 
       - name: Upload BennuGD2 artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BennuGD2-macosx
           path: packages/x86_64-apple-darwin14-*.tgz
@@ -270,10 +270,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download BennuGD2 Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: BennuGD2-${{ matrix.platform }}
           path: ./dist/${{ matrix.platform }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -279,7 +279,7 @@ jobs:
           path: ./dist/${{ matrix.platform }}
 
       - name: Upload BennuGD2 Artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ./dist/${{ matrix.platform }}/*
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up environment for linux32
         run: |
@@ -32,7 +32,7 @@ jobs:
           ./build.sh packages
 
       - name: Upload BennuGD2 artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BennuGD2-linux32
           path: packages/bgd2-*.tgz
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up environment for linux
         run: |
@@ -61,7 +61,7 @@ jobs:
           ./build.sh packages
 
       - name: Upload BennuGD2 artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BennuGD2-linux
           path: packages/bgd2-*.tgz          
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up environment
         run: |
@@ -139,7 +139,7 @@ jobs:
           fi
 
       - name: Upload BennuGD2 artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BennuGD2-windows
           path: packages/bgd2-x86_64-w64-mingw32-*.rar
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up environment
         run: |
@@ -219,7 +219,7 @@ jobs:
           fi
 
       - name: Upload BennuGD2 artifacts for 32-bit
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BennuGD2-windows32
           path: packages/bgd2-i686-w64-mingw32-*.rar
@@ -231,7 +231,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up osxcross
         run: |
@@ -269,7 +269,7 @@ jobs:
           ./build.sh packages
 
       - name: Upload BennuGD2 artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BennuGD2-macosx
           path: packages/x86_64-apple-darwin14-*.tgz
@@ -290,10 +290,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download BennuGD2 Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: BennuGD2-${{ matrix.platform }}
           path: ./dist/${{ matrix.platform }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build and Release BennuGD2 Packages](https://github.com/SplinterGU/BennuGD2/actions/workflows/build-and-release.yml/badge.svg)](https://github.com/SplinterGU/BennuGD2/actions/workflows/build-and-release.yml)
+
 # BennuGD2
 
 Welcome to BennuGD2! BennuGD2 is a game development system focused on ease of use and portability.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build and Release BennuGD2 Packages](https://github.com/SplinterGU/BennuGD2/actions/workflows/build-and-release.yml/badge.svg)](https://github.com/SplinterGU/BennuGD2/actions/workflows/build-and-release.yml)
+[![Wiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/SplinterGU/BennuGD2)
+![GitHub all releases](https://img.shields.io/github/downloads/SplinterGU/BennuGD2/total)
 
 # BennuGD2
 


### PR DESCRIPTION
### Changes

- `linux32` now uses `ubuntu-22.04` runner to maintain support for the i386 architecture
- `linux64` updated to use `ubuntu-latest` runner
- Updated GitHub Actions to the latest versions:
  - `actions/checkout@v6`
  - `actions/download-artifact@v5`
  - `actions/upload-artifact@v5`
  - `softprops/action-gh-release@v2`
- Added a build/status **badge** to the `README`

<img width="325" height="166" alt="image" src="https://github.com/user-attachments/assets/e900a931-9b8d-4178-9e91-628cbde7a7f5" />

- Releases
<img width="1405" height="792" alt="image" src="https://github.com/user-attachments/assets/2fc93da3-6d22-4ae7-a4e4-2540d425c559" />

https://github.com/humbertodias/BennuGD2/releases/tag/v1.0.1